### PR TITLE
Only define methods on SuiteSparse.UMFPACK if GPL libs present

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseMatricesCSR"
 uuid = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 authors = ["Víctor Sande <vsande@cimne.upc.edu>", "Francesc Verdugo <fverdugo@cimne.upc.edu>"]
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/SparseMatrixCSR.jl
+++ b/src/SparseMatrixCSR.jl
@@ -140,6 +140,8 @@ function LinearAlgebra.lu(a::SparseMatrixCSR{1})
   Transpose(lu(SparseMatrixCSC(a.m,a.n,a.rowptr,a.colval,a.nzval)))
 end
 
+if Base.USE_GPL_LIBS
+
 function LinearAlgebra.lu!(
     translu::Transpose{T,<:SuiteSparse.UMFPACK.UmfpackLU{T}},
     a::SparseMatrixCSR{1}) where {T}
@@ -153,6 +155,8 @@ function LinearAlgebra.lu!(
   colval = _copy_and_increment(a.colval)
   Transpose(lu!(translu.parent,SparseMatrixCSC(a.m,a.n,rowptr,colval,a.nzval)))
 end
+
+end # Base.USE_GPL_LIBS
 
 size(S::SparseMatrixCSR) = (S.m, S.n)
 IndexStyle(::Type{<:SparseMatrixCSR}) = IndexCartesian()

--- a/test/SparseMatrixCSR.jl
+++ b/test/SparseMatrixCSR.jl
@@ -133,10 +133,14 @@ for Bi in (0,1)
   end
 end
 
-I = [1,1,2,2,2,3,3]
-J = [1,2,1,2,3,2,3]
-V = [4.0,1.0,-1.0,4.0,1.0,-1.0,4.0]
-test_lu(0,I,J,V)
-test_lu(1,I,J,V)
+if Base.USE_GPL_LIBS  # `lu!` requires `SuiteSparse.UMFPACK`
+    I = [1,1,2,2,2,3,3]
+    J = [1,2,1,2,3,2,3]
+    V = [4.0,1.0,-1.0,4.0,1.0,-1.0,4.0]
+    test_lu(0,I,J,V)
+    test_lu(1,I,J,V)
+else
+    @warn "Tests run without GPL libraries."
+end
 
 end # module


### PR DESCRIPTION
Fix package on Julia versions built without GPL libraries (i.e. with `USE_GPL_LIBS=0`)

This is so packages depending on SparseMatricesCSR.jl will still compile, even on Julia versions built without GPL libraries. Prompted by https://github.com/dmlc/XGBoost.jl/issues/157


Before we'd get 
```julia
julia> using SparseMatricesCSR
[ Info: Precompiling SparseMatricesCSR [a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1]
ERROR: LoadError: UndefVarError: `UMFPACK` not defined
Stacktrace:
 [1] getproperty(x::Module, f::Symbol)
   @ Base ./Base.jl:31
 [2] top-level scope
   @ ~/repos/SparseMatricesCSR.jl/src/SparseMatrixCSR.jl:143
 [3] include(mod::Module, _path::String)
   @ Base ./Base.jl:456
 [4] include(x::String)
   @ SparseMatricesCSR ~/repos/SparseMatricesCSR.jl/src/SparseMatricesCSR.jl:1
 [5] top-level scope
   @ ~/repos/SparseMatricesCSR.jl/src/SparseMatricesCSR.jl:17
 [6] include
   @ ./Base.jl:456 [inlined]
 [7] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
   @ Base ./loading.jl:1900
 [8] top-level scope
   @ stdin:2
in expression starting at /Users/nickr/repos/SparseMatricesCSR.jl/src/SparseMatrixCSR.jl:143
in expression starting at /Users/nickr/repos/SparseMatricesCSR.jl/src/SparseMatricesCSR.jl:1
in expression starting at stdin:2
ERROR: Failed to precompile SparseMatricesCSR [a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1] to "/Users/nickr/.julia/compiled/v1.10/SparseMatricesCSR/jl_iZfEOo".
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::IO, internal_stdout::IO, keep_loaded_modules::Bool)
   @ Base ./loading.jl:2124
 [3] compilecache
   @ ./loading.jl:2016 [inlined]
 [4] _require(pkg::Base.PkgId, env::String)
   @ Base ./loading.jl:1660
 [5] _require_prelocked(uuidkey::Base.PkgId, env::String)
   @ Base ./loading.jl:1515
 [6] macro expansion
   @ ./loading.jl:1503 [inlined]
 [7] macro expansion
   @ ./lock.jl:267 [inlined]
 [8] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:1466
```

Now the package compiles as expected
```julia
julia> using SparseMatricesCSR
[ Info: Precompiling SparseMatricesCSR [a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1]

julia>
```

