### PR TITLE
Adjust to `TransposeFactorization`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseMatricesCSR"
 uuid = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 authors = ["Víctor Sande <vsande@cimne.upc.edu>", "Francesc Verdugo <fverdugo@cimne.upc.edu>"]
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/SparseMatrixCSR.jl
+++ b/src/SparseMatrixCSR.jl
@@ -133,27 +133,31 @@ end
 function LinearAlgebra.lu(a::SparseMatrixCSR{0})
   rowptr = _copy_and_increment(a.rowptr)
   colval = _copy_and_increment(a.colval)
-  Transpose(lu(SparseMatrixCSC(a.m,a.n,rowptr,colval,a.nzval)))
+  transpose(lu(SparseMatrixCSC(a.m,a.n,rowptr,colval,a.nzval)))
 end
 
 function LinearAlgebra.lu(a::SparseMatrixCSR{1})
-  Transpose(lu(SparseMatrixCSC(a.m,a.n,a.rowptr,a.colval,a.nzval)))
+  transpose(lu(SparseMatrixCSC(a.m,a.n,a.rowptr,a.colval,a.nzval)))
 end
 
 if Base.USE_GPL_LIBS
 
+const TransposeFact = isdefined(LinearAlgebra, :TransposeFact) ?
+  LinearAlgebra.TransposeFact :
+  Transpose
+
 function LinearAlgebra.lu!(
-    translu::Transpose{T,<:SuiteSparse.UMFPACK.UmfpackLU{T}},
+    translu::TransposeFact{T,<:SuiteSparse.UMFPACK.UmfpackLU{T}},
     a::SparseMatrixCSR{1}) where {T}
-  Transpose(lu!(translu.parent,SparseMatrixCSC(a.m,a.n,a.rowptr,a.colval,a.nzval)))
+  transpose(lu!(translu.parent,SparseMatrixCSC(a.m,a.n,a.rowptr,a.colval,a.nzval)))
 end
 
 function LinearAlgebra.lu!(
-  translu::Transpose{T,<:SuiteSparse.UMFPACK.UmfpackLU{T}},
+  translu::TransposeFact{T,<:SuiteSparse.UMFPACK.UmfpackLU{T}},
   a::SparseMatrixCSR{0}) where {T}
   rowptr = _copy_and_increment(a.rowptr)
   colval = _copy_and_increment(a.colval)
-  Transpose(lu!(translu.parent,SparseMatrixCSC(a.m,a.n,rowptr,colval,a.nzval)))
+  transpose(lu!(translu.parent,SparseMatrixCSC(a.m,a.n,rowptr,colval,a.nzval)))
 end
 
 end # Base.USE_GPL_LIBS

--- a/src/SparseMatrixCSR.jl
+++ b/src/SparseMatrixCSR.jl
@@ -142,8 +142,8 @@ end
 
 if Base.USE_GPL_LIBS
 
-const TransposeFact = isdefined(LinearAlgebra, :TransposeFact) ?
-  LinearAlgebra.TransposeFact :
+const TransposeFact = isdefined(LinearAlgebra, :TransposeFactorization) ?
+  LinearAlgebra.TransposeFactorization :
   Transpose
 
 function LinearAlgebra.lu!(


### PR DESCRIPTION
This prepares the ground for https://github.com/JuliaLang/julia/pull/46874. First, it doesn't enforce the `Transpose` wrapper type, but leaves it to dispatch which wrapper to use. Second, it picks either `Transpose` or `TransposeFactorization`.