### PR TITLE
Add method for sparsecsr() that takes an AbstractMatrix

### DIFF
--- a/src/SparseMatrixCSR.jl
+++ b/src/SparseMatrixCSR.jl
@@ -93,9 +93,11 @@ Create  a `SparseMatrixCSR` with `Bi`-based indexing (1 by default)
 from the same `args...` as one constructs a `SparseMatrixCSC`
 with the [`SparseArrays.sparse`](@extref) function.
 """
+sparsecsr(A::AbstractMatrix{T}) where T = convert(SparseMatrixCSR{1,T,Int64}, A)
 sparsecsr(I,J,V) = SparseMatrixCSR(transpose(sparse(J,I,V,dimlub(J),dimlub(I))))
 sparsecsr(I,J,V,m,n) = SparseMatrixCSR(transpose(sparse(J,I,V,n,m)))
 sparsecsr(I,J,V,m,n,combine) = SparseMatrixCSR(transpose(sparse(J,I,V,n,m,combine)))
+sparsecsr(::Val{Bi},A::AbstractMatrix{T}) where {Bi,T} = convert(SparseMatrixCSR{Bi,T,Int64}, A)
 sparsecsr(::Val{Bi},I,J,V) where Bi = SparseMatrixCSR{Bi}(transpose(sparse(J,I,V,dimlub(J),dimlub(I))))
 sparsecsr(::Val{Bi},I,J,V,m,n) where Bi = SparseMatrixCSR{Bi}(transpose(sparse(J,I,V,n,m)))
 sparsecsr(::Val{Bi},I,J,V,m,n,combine) where Bi = SparseMatrixCSR{Bi}(transpose(sparse(J,I,V,n,m,combine)))

--- a/test/SparseMatrixCSR.jl
+++ b/test/SparseMatrixCSR.jl
@@ -47,6 +47,18 @@ function test_csr(Bi,Tv,Ti)
     end
   end
 
+  if Ti == Int64
+      dense = rand(Tv, maxrows,maxcols)
+      CSR = sparsecsr(Val(Bi), dense)
+      @test isa(CSR,SparseMatrixCSR{Bi,Tv,Ti})
+      @test CSR == dense
+      if Bi == 1
+          CSR = sparsecsr(dense)
+          @test CSR == dense
+          @test isa(CSR,SparseMatrixCSR{Bi,Tv,Ti})
+      end
+  end
+
   CSC = sparse(I,J,V,maxrows,maxcols)
   if Bi == 1
     CSR = sparsecsr(I,J,V,maxrows,maxcols)


### PR DESCRIPTION
For convenience, and consistency with `SparseArrays.sparse`.